### PR TITLE
Front Page Jump

### DIFF
--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -33,6 +33,7 @@ img {
   max-width: 50%;
   margin-top: 15%;
   z-index:100;
+  min-height: 400px;
 }
 
 .powered {
@@ -53,6 +54,7 @@ img {
 @media screen and (max-width:480px){
   img {
     max-width: 90%;
+    min-height: 200px;
   }
 }
 


### PR DESCRIPTION
Giving a min-height to image stops content from jumping when it loads